### PR TITLE
geolocation to the posts

### DIFF
--- a/client/src/components/Upload.jsx
+++ b/client/src/components/Upload.jsx
@@ -1,16 +1,30 @@
 import React from 'react';
 import { updateImage, submitImage } from '../helpers/helpers.js';
+import gps from '../helpers/gps.js';
 
 class Upload extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       photo: null,
-      trailId: window.location.href.split('id=')[1]
+      trailId: window.location.href.split('id=')[1],
+      lat: null,
+      lng: null,
     }
     this.submitImage = submitImage.bind(this);
     this.updateImage = updateImage.bind(this);
+  }
 
+  componentWillMount() {
+    gps.getLocation()
+    .then(value => {
+      //First, we are going to get the location, then set it inside of an object.
+      
+      //We then set that object as the mapCenter, which dictates where the Google Map locates at.
+      this.setState({lat: value.coords.latitude,
+                     lng: value.coords.longitude})
+    })
+    .catch(err => console.log('location access denied: ', err));
   }
 
   componentDidMount() {

--- a/client/src/helpers/helpers.js
+++ b/client/src/helpers/helpers.js
@@ -158,13 +158,15 @@ module.exports.submitImage = function(e) {
   form.append('image', this.state.photo[0])
   axios.post('https://api.imgur.com/3/image', form)
   .then((res) => {
-    console.log('this is the URL: ', window.location.href);
+    console.log('state: ', this.state);
     let metaPhoto = {
       title: this.state.photo[0].name,
       text: document.getElementsByTagName('textarea')[0].value,
       image_url: res.data.data.link,
       flag_comments: [],
-      trail_id: this.state.trailId
+      latitude: this.state.lng,
+      longitude: this.state.lat,
+      trail_id: this.state.trailId,
     };
     return axios.post('/api/posts', {photo: metaPhoto})
       .then(res => console.log('success: ', res))

--- a/client/src/helpers/helpers.js
+++ b/client/src/helpers/helpers.js
@@ -158,7 +158,6 @@ module.exports.submitImage = function(e) {
   form.append('image', this.state.photo[0])
   axios.post('https://api.imgur.com/3/image', form)
   .then((res) => {
-    console.log('state: ', this.state);
     let metaPhoto = {
       title: this.state.photo[0].name,
       text: document.getElementsByTagName('textarea')[0].value,

--- a/server/api-router.js
+++ b/server/api-router.js
@@ -25,9 +25,11 @@ router.get('/currentUser', (req, res) => {
 //
 // And the HTTP response will contain all of this data plus
 // a timestamp that the database will create automatically
+
+
 router.post('/posts', (req, res) => {
   var post = req.body.photo;
-  db.createPost(req.user.email, post.trail_id, post.title, post.text, post.image_url).then((post) => {
+  db.createPost(req.user.email, post.trail_id, post.title, post.text, post.image_url, post.latitude, post.longitude).then((post) => {
     res.end(JSON.stringify(post));
   });
 });


### PR DESCRIPTION
-the upload component now queries the gps helper to get location, and sends in that lat/long in with the post. 
-Allows for markers to be placed where the photo was uploaded. Assumption: expecting users to submit photos from the location at which they were submitted. If this assumption fails, then the alternative would be getting the geolocation that is attached to the photo itself when it was taken. 